### PR TITLE
Fix 'text file busy' error

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -160,6 +160,7 @@ func CreateFile(path string, reader io.Reader, perm os.FileMode) error {
 	if err != nil {
 		return err
 	}
+	defer dest.Close()
 	if _, err := io.Copy(dest, reader); err != nil {
 		return err
 	}


### PR DESCRIPTION
Forgot to close file during ADD/COPY which created errors during RUN
